### PR TITLE
Add separate store for changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -843,6 +843,7 @@ class TreeWardenMap {
         
         const trees = stores.trees.get();
         const patchset = stores.patchset.get();
+        const patches = stores.patches.get();
         
         trees.forEach((tree, index) => {
             const listItem = document.createElement('div');
@@ -852,6 +853,11 @@ class TreeWardenMap {
             // Check for patchset changes (fast check)
             if (patchset.has(tree.id)) {
                 listItem.classList.add('has-patchset');
+            }
+            
+            // Check for patch store changes
+            if (patches.has(tree.id)) {
+                listItem.classList.add('has-patches');
             }
             
             // Only validate if tree has patchset changes (optimization)

--- a/nanostore.js
+++ b/nanostore.js
@@ -65,38 +65,38 @@ patchsetStore.subscribe((patchset) => {
     }
 });
 
-// Load changes from localStorage if available
-let initialChanges = new Map();
+// Load patches from localStorage if available
+let initialPatches = new Map();
 try {
-    const savedChanges = localStorage.getItem('treewarden_changes');
-    if (savedChanges) {
-        const parsedChanges = JSON.parse(savedChanges);
+    const savedPatches = localStorage.getItem('treewarden_patches');
+    if (savedPatches) {
+        const parsedPatches = JSON.parse(savedPatches);
         // Convert back to Map from object
-        initialChanges = new Map(Object.entries(parsedChanges));
-        console.log('📦 Loaded changes from localStorage:', initialChanges.size, 'entries');
+        initialPatches = new Map(Object.entries(parsedPatches));
+        console.log('📦 Loaded patches from localStorage:', initialPatches.size, 'entries');
     }
 } catch (error) {
-    console.error('❌ Error loading changes from localStorage:', error);
+    console.error('❌ Error loading patches from localStorage:', error);
 }
 
-// Changes store - tracks modifications with structure:
+// Patch store - tracks modifications with structure:
 // Key: OSM ID (string)
 // Value: {
 //   osmId: string,
 //   oldVersion: number,
 //   changes: Array<{key: string, value: any}>
 // }
-const changesStore = new NanoStore(initialChanges);
+const patchStore = new NanoStore(initialPatches);
 
-// Save changes to localStorage whenever it changes
-changesStore.subscribe((changes) => {
+// Save patches to localStorage whenever it changes
+patchStore.subscribe((patches) => {
     try {
         // Convert Map to object for JSON serialization
-        const changesObject = Object.fromEntries(changes);
-        localStorage.setItem('treewarden_changes', JSON.stringify(changesObject));
-        console.log('💾 Saved changes to localStorage:', changes.size, 'entries');
+        const patchesObject = Object.fromEntries(patches);
+        localStorage.setItem('treewarden_patches', JSON.stringify(patchesObject));
+        console.log('💾 Saved patches to localStorage:', patches.size, 'entries');
     } catch (error) {
-        console.error('❌ Error saving changes to localStorage:', error);
+        console.error('❌ Error saving patches to localStorage:', error);
     }
 });
 
@@ -108,7 +108,7 @@ window.stores = {
     trees: treesStore,
     selectedTree: selectedTreeStore,
     patchset: patchsetStore,
-    changes: changesStore,
+    patches: patchStore,
     basemap: basemapStore,
     loading: loadingStore
 }; 

--- a/nanostore.js
+++ b/nanostore.js
@@ -65,6 +65,41 @@ patchsetStore.subscribe((patchset) => {
     }
 });
 
+// Load changes from localStorage if available
+let initialChanges = new Map();
+try {
+    const savedChanges = localStorage.getItem('treewarden_changes');
+    if (savedChanges) {
+        const parsedChanges = JSON.parse(savedChanges);
+        // Convert back to Map from object
+        initialChanges = new Map(Object.entries(parsedChanges));
+        console.log('📦 Loaded changes from localStorage:', initialChanges.size, 'entries');
+    }
+} catch (error) {
+    console.error('❌ Error loading changes from localStorage:', error);
+}
+
+// Changes store - tracks modifications with structure:
+// Key: OSM ID (string)
+// Value: {
+//   osmId: string,
+//   oldVersion: number,
+//   changes: Array<{key: string, value: any}>
+// }
+const changesStore = new NanoStore(initialChanges);
+
+// Save changes to localStorage whenever it changes
+changesStore.subscribe((changes) => {
+    try {
+        // Convert Map to object for JSON serialization
+        const changesObject = Object.fromEntries(changes);
+        localStorage.setItem('treewarden_changes', JSON.stringify(changesObject));
+        console.log('💾 Saved changes to localStorage:', changes.size, 'entries');
+    } catch (error) {
+        console.error('❌ Error saving changes to localStorage:', error);
+    }
+});
+
 const basemapStore = new NanoStore('cyclosm');
 const loadingStore = new NanoStore(false);
 
@@ -73,6 +108,7 @@ window.stores = {
     trees: treesStore,
     selectedTree: selectedTreeStore,
     patchset: patchsetStore,
+    changes: changesStore,
     basemap: basemapStore,
     loading: loadingStore
 }; 

--- a/styles.css
+++ b/styles.css
@@ -601,6 +601,16 @@ body.sidebar-open .leaflet-control-layers {
     border-left: 3px solid #28a745;
 }
 
+.tree-list-item.has-patches {
+    background-color: #e2e3ff;
+    border-left: 3px solid #6f42c1;
+}
+
+.tree-list-item.has-patchset.has-patches {
+    background-color: #fff0e6;
+    border-left: 3px solid #fd7e14;
+}
+
 .tree-list-item-icon {
     width: 12px;
     height: 12px;

--- a/test_changes_store.html
+++ b/test_changes_store.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Changes Store Test</title>
+    <style>
+        body { 
+            font-family: Arial, sans-serif; 
+            margin: 20px; 
+            background-color: #f5f5f5;
+        }
+        .container { 
+            max-width: 800px; 
+            margin: 0 auto; 
+            background: white; 
+            padding: 20px; 
+            border-radius: 8px; 
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .test-section { 
+            margin: 20px 0; 
+            padding: 15px; 
+            border: 1px solid #ddd; 
+            border-radius: 4px;
+        }
+        .test-section h3 {
+            margin-top: 0;
+            color: #333;
+        }
+        button { 
+            padding: 8px 16px; 
+            margin: 5px; 
+            border: none; 
+            border-radius: 4px; 
+            background-color: #007bff; 
+            color: white; 
+            cursor: pointer;
+        }
+        button:hover { 
+            background-color: #0056b3; 
+        }
+        .clear-btn {
+            background-color: #dc3545;
+        }
+        .clear-btn:hover {
+            background-color: #c82333;
+        }
+        pre { 
+            background: #f8f9fa; 
+            padding: 10px; 
+            border-radius: 4px; 
+            overflow-x: auto;
+            border: 1px solid #e9ecef;
+        }
+        .log {
+            margin-top: 10px;
+            padding: 10px;
+            background-color: #f8f9fa;
+            border-left: 4px solid #007bff;
+            font-family: monospace;
+            font-size: 12px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🌳 Changes Store Test</h1>
+        <p>Test für den neuen Changes Store für Baumfaten-Änderungen</p>
+
+        <div class="test-section">
+            <h3>Store Status</h3>
+            <div id="store-status">Lade Store...</div>
+            <button onclick="updateStoreStatus()">Status aktualisieren</button>
+        </div>
+
+        <div class="test-section">
+            <h3>Test: Änderung hinzufügen</h3>
+            <p>Fügt eine Beispiel-Änderung für OSM ID 12345 hinzu:</p>
+            <button onclick="addTestChange()">Test-Änderung hinzufügen</button>
+            <button onclick="addAnotherChange()">Weitere Änderung hinzufügen</button>
+        </div>
+
+        <div class="test-section">
+            <h3>Test: Mehrere Änderungen für einen Baum</h3>
+            <p>Fügt mehrere Änderungen für denselben Baum hinzu:</p>
+            <button onclick="addMultipleChanges()">Mehrere Änderungen hinzufügen</button>
+        </div>
+
+        <div class="test-section">
+            <h3>Store Inhalt</h3>
+            <pre id="store-content">Noch keine Daten geladen...</pre>
+            <button onclick="showStoreContent()">Inhalt anzeigen</button>
+            <button class="clear-btn" onclick="clearStore()">Store leeren</button>
+        </div>
+
+        <div class="test-section">
+            <h3>Store Subscription Test</h3>
+            <p>Zeigt Änderungen in Echtzeit an:</p>
+            <div class="log" id="subscription-log">Warte auf Änderungen...</div>
+        </div>
+    </div>
+
+    <script src="nanostore.js"></script>
+    <script>
+        // Subscription für Echtzeit-Updates
+        let subscriptionLog = document.getElementById('subscription-log');
+        let logEntries = [];
+
+        function addLogEntry(message) {
+            const timestamp = new Date().toLocaleTimeString();
+            logEntries.push(`[${timestamp}] ${message}`);
+            if (logEntries.length > 10) {
+                logEntries.shift(); // Nur die letzten 10 Einträge behalten
+            }
+            subscriptionLog.innerHTML = logEntries.join('<br>');
+        }
+
+        // Subscribe to changes store
+        stores.changes.subscribe((newChanges, oldChanges) => {
+            const newSize = newChanges.size;
+            const oldSize = oldChanges ? oldChanges.size : 0;
+            addLogEntry(`Store geändert: ${newSize} Einträge (vorher: ${oldSize})`);
+            updateStoreStatus();
+            showStoreContent();
+        });
+
+        function updateStoreStatus() {
+            const changesStore = stores.changes.get();
+            const statusDiv = document.getElementById('store-status');
+            statusDiv.innerHTML = `
+                <strong>Changes Store:</strong> ${changesStore.size} Einträge<br>
+                <strong>Typ:</strong> ${changesStore.constructor.name}<br>
+                <strong>LocalStorage Key:</strong> treewarden_changes
+            `;
+        }
+
+        function showStoreContent() {
+            const changesStore = stores.changes.get();
+            const contentPre = document.getElementById('store-content');
+            
+            if (changesStore.size === 0) {
+                contentPre.textContent = 'Store ist leer';
+                return;
+            }
+
+            const changesObject = Object.fromEntries(changesStore);
+            contentPre.textContent = JSON.stringify(changesObject, null, 2);
+        }
+
+        function addTestChange() {
+            const changesStore = stores.changes.get();
+            const newChanges = new Map(changesStore);
+            
+            const osmId = '12345';
+            const changeEntry = {
+                osmId: osmId,
+                oldVersion: 3,
+                changes: [
+                    { key: 'species', value: 'Malus domestica' },
+                    { key: 'height', value: '5.2' }
+                ]
+            };
+            
+            newChanges.set(osmId, changeEntry);
+            stores.changes.set(newChanges);
+            
+            addLogEntry(`Test-Änderung für OSM ID ${osmId} hinzugefügt`);
+        }
+
+        function addAnotherChange() {
+            const changesStore = stores.changes.get();
+            const newChanges = new Map(changesStore);
+            
+            const osmId = '67890';
+            const changeEntry = {
+                osmId: osmId,
+                oldVersion: 1,
+                changes: [
+                    { key: 'genus', value: 'Pyrus' },
+                    { key: 'species', value: 'Pyrus communis' },
+                    { key: 'diameter_crown', value: '4.5' }
+                ]
+            };
+            
+            newChanges.set(osmId, changeEntry);
+            stores.changes.set(newChanges);
+            
+            addLogEntry(`Weitere Änderung für OSM ID ${osmId} hinzugefügt`);
+        }
+
+        function addMultipleChanges() {
+            const changesStore = stores.changes.get();
+            const newChanges = new Map(changesStore);
+            
+            const osmId = '12345';
+            
+            // Prüfen ob bereits Änderungen für diesen Baum existieren
+            if (newChanges.has(osmId)) {
+                const existingEntry = newChanges.get(osmId);
+                // Neue Änderungen zu bestehenden hinzufügen
+                existingEntry.changes.push(
+                    { key: 'circumference', value: '85' },
+                    { key: 'leaf_cycle', value: 'deciduous' }
+                );
+                addLogEntry(`Zusätzliche Änderungen für OSM ID ${osmId} hinzugefügt`);
+            } else {
+                // Neuen Eintrag erstellen
+                const changeEntry = {
+                    osmId: osmId,
+                    oldVersion: 2,
+                    changes: [
+                        { key: 'circumference', value: '85' },
+                        { key: 'leaf_cycle', value: 'deciduous' },
+                        { key: 'fruit', value: 'apple' }
+                    ]
+                };
+                newChanges.set(osmId, changeEntry);
+                addLogEntry(`Mehrere Änderungen für OSM ID ${osmId} erstellt`);
+            }
+            
+            stores.changes.set(newChanges);
+        }
+
+        function clearStore() {
+            if (confirm('Möchten Sie wirklich alle Änderungen löschen?')) {
+                stores.changes.set(new Map());
+                addLogEntry('Store wurde geleert');
+            }
+        }
+
+        // Initial load
+        updateStoreStatus();
+        showStoreContent();
+        addLogEntry('Changes Store Test gestartet');
+    </script>
+</body>
+</html>

--- a/test_changes_store.html
+++ b/test_changes_store.html
@@ -65,8 +65,8 @@
 </head>
 <body>
     <div class="container">
-        <h1>🌳 Changes Store Test</h1>
-        <p>Test für den neuen Changes Store für Baumfaten-Änderungen</p>
+        <h1>🌳 Patch Store Test</h1>
+        <p>Test für den neuen Patch Store für Baumfaten-Änderungen</p>
 
         <div class="test-section">
             <h3>Store Status</h3>
@@ -116,44 +116,44 @@
             subscriptionLog.innerHTML = logEntries.join('<br>');
         }
 
-        // Subscribe to changes store
-        stores.changes.subscribe((newChanges, oldChanges) => {
-            const newSize = newChanges.size;
-            const oldSize = oldChanges ? oldChanges.size : 0;
+        // Subscribe to patch store
+        stores.patches.subscribe((newPatches, oldPatches) => {
+            const newSize = newPatches.size;
+            const oldSize = oldPatches ? oldPatches.size : 0;
             addLogEntry(`Store geändert: ${newSize} Einträge (vorher: ${oldSize})`);
             updateStoreStatus();
             showStoreContent();
         });
 
         function updateStoreStatus() {
-            const changesStore = stores.changes.get();
+            const patchStore = stores.patches.get();
             const statusDiv = document.getElementById('store-status');
             statusDiv.innerHTML = `
-                <strong>Changes Store:</strong> ${changesStore.size} Einträge<br>
-                <strong>Typ:</strong> ${changesStore.constructor.name}<br>
-                <strong>LocalStorage Key:</strong> treewarden_changes
+                <strong>Patch Store:</strong> ${patchStore.size} Einträge<br>
+                <strong>Typ:</strong> ${patchStore.constructor.name}<br>
+                <strong>LocalStorage Key:</strong> treewarden_patches
             `;
         }
 
         function showStoreContent() {
-            const changesStore = stores.changes.get();
+            const patchStore = stores.patches.get();
             const contentPre = document.getElementById('store-content');
             
-            if (changesStore.size === 0) {
+            if (patchStore.size === 0) {
                 contentPre.textContent = 'Store ist leer';
                 return;
             }
 
-            const changesObject = Object.fromEntries(changesStore);
-            contentPre.textContent = JSON.stringify(changesObject, null, 2);
+            const patchesObject = Object.fromEntries(patchStore);
+            contentPre.textContent = JSON.stringify(patchesObject, null, 2);
         }
 
         function addTestChange() {
-            const changesStore = stores.changes.get();
-            const newChanges = new Map(changesStore);
+            const patchStore = stores.patches.get();
+            const newPatches = new Map(patchStore);
             
             const osmId = '12345';
-            const changeEntry = {
+            const patchEntry = {
                 osmId: osmId,
                 oldVersion: 3,
                 changes: [
@@ -162,18 +162,18 @@
                 ]
             };
             
-            newChanges.set(osmId, changeEntry);
-            stores.changes.set(newChanges);
+            newPatches.set(osmId, patchEntry);
+            stores.patches.set(newPatches);
             
             addLogEntry(`Test-Änderung für OSM ID ${osmId} hinzugefügt`);
         }
 
         function addAnotherChange() {
-            const changesStore = stores.changes.get();
-            const newChanges = new Map(changesStore);
+            const patchStore = stores.patches.get();
+            const newPatches = new Map(patchStore);
             
             const osmId = '67890';
-            const changeEntry = {
+            const patchEntry = {
                 osmId: osmId,
                 oldVersion: 1,
                 changes: [
@@ -183,21 +183,21 @@
                 ]
             };
             
-            newChanges.set(osmId, changeEntry);
-            stores.changes.set(newChanges);
+            newPatches.set(osmId, patchEntry);
+            stores.patches.set(newPatches);
             
             addLogEntry(`Weitere Änderung für OSM ID ${osmId} hinzugefügt`);
         }
 
         function addMultipleChanges() {
-            const changesStore = stores.changes.get();
-            const newChanges = new Map(changesStore);
+            const patchStore = stores.patches.get();
+            const newPatches = new Map(patchStore);
             
             const osmId = '12345';
             
             // Prüfen ob bereits Änderungen für diesen Baum existieren
-            if (newChanges.has(osmId)) {
-                const existingEntry = newChanges.get(osmId);
+            if (newPatches.has(osmId)) {
+                const existingEntry = newPatches.get(osmId);
                 // Neue Änderungen zu bestehenden hinzufügen
                 existingEntry.changes.push(
                     { key: 'circumference', value: '85' },
@@ -206,7 +206,7 @@
                 addLogEntry(`Zusätzliche Änderungen für OSM ID ${osmId} hinzugefügt`);
             } else {
                 // Neuen Eintrag erstellen
-                const changeEntry = {
+                const patchEntry = {
                     osmId: osmId,
                     oldVersion: 2,
                     changes: [
@@ -215,16 +215,16 @@
                         { key: 'fruit', value: 'apple' }
                     ]
                 };
-                newChanges.set(osmId, changeEntry);
+                newPatches.set(osmId, patchEntry);
                 addLogEntry(`Mehrere Änderungen für OSM ID ${osmId} erstellt`);
             }
             
-            stores.changes.set(newChanges);
+            stores.patches.set(newPatches);
         }
 
         function clearStore() {
             if (confirm('Möchten Sie wirklich alle Änderungen löschen?')) {
-                stores.changes.set(new Map());
+                stores.patches.set(new Map());
                 addLogEntry('Store wurde geleert');
             }
         }
@@ -232,7 +232,7 @@
         // Initial load
         updateStoreStatus();
         showStoreContent();
-        addLogEntry('Changes Store Test gestartet');
+        addLogEntry('Patch Store Test gestartet');
     </script>
 </body>
 </html>

--- a/test_changes_store.html
+++ b/test_changes_store.html
@@ -99,6 +99,16 @@
             <p>Zeigt Änderungen in Echtzeit an:</p>
             <div class="log" id="subscription-log">Warte auf Änderungen...</div>
         </div>
+
+        <div class="test-section">
+            <h3>TreeList Integration Test</h3>
+            <p>Testet die Integration mit der TreeList Komponente:</p>
+            <button onclick="testTreeListIntegration()">TreeList Integration testen</button>
+            <div id="treelist-test-result" style="margin-top: 10px; padding: 10px; background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; display: none;">
+                <strong>Test Ergebnis:</strong>
+                <div id="treelist-test-content"></div>
+            </div>
+        </div>
     </div>
 
     <script src="nanostore.js"></script>
@@ -227,6 +237,47 @@
                 stores.patches.set(new Map());
                 addLogEntry('Store wurde geleert');
             }
+        }
+
+        function testTreeListIntegration() {
+            const resultDiv = document.getElementById('treelist-test-result');
+            const contentDiv = document.getElementById('treelist-test-content');
+            
+            // Simulate some test data
+            const testTrees = [
+                { id: '12345', properties: { genus: 'Malus' } },
+                { id: '67890', properties: { genus: 'Pyrus' } },
+                { id: '11111', properties: { genus: 'Prunus' } }
+            ];
+            
+            // Add test trees to trees store
+            stores.trees.set(testTrees);
+            
+            // Add some patches
+            const patches = new Map();
+            patches.set('12345', {
+                osmId: '12345',
+                oldVersion: 3,
+                changes: [{ key: 'species', value: 'Malus domestica' }]
+            });
+            patches.set('67890', {
+                osmId: '67890',
+                oldVersion: 1,
+                changes: [{ key: 'genus', value: 'Pyrus' }]
+            });
+            stores.patches.set(patches);
+            
+            // Check if the logic would work (simulate the TreeList logic)
+            let testResults = [];
+            testTrees.forEach(tree => {
+                const hasPatch = stores.patches.get().has(tree.id);
+                testResults.push(`Tree ${tree.id} (${tree.properties.genus}): ${hasPatch ? 'HAT PATCHES ✅' : 'Keine Patches'}`);
+            });
+            
+            contentDiv.innerHTML = testResults.join('<br>');
+            resultDiv.style.display = 'block';
+            
+            addLogEntry('TreeList Integration Test durchgeführt');
         }
 
         // Initial load


### PR DESCRIPTION
Add a new `changes` nanostore to track modifications to tree data, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-731f362c-ceac-45d1-aafd-2c8b2addca4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-731f362c-ceac-45d1-aafd-2c8b2addca4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>