### PR TITLE
Fetch overpass api data with timeout

### DIFF
--- a/app.js
+++ b/app.js
@@ -322,13 +322,13 @@ class TreeWardenMap {
     buildOverpassQuery(bounds) {
         const { south, west, north, east } = bounds;
         const filter = '["natural"="tree"]';
-        const query = `[out:json][timeout:25];node${filter}(${south},${west},${north},${east});out meta;`;
+        const query = `[out:json][timeout:180];node${filter}(${south},${west},${north},${east});out meta;`;
         return query;
     }
     
     buildOrchardQuery(bounds) {
         const { south, west, north, east } = bounds;
-        const query = `[out:json][timeout:25];
+        const query = `[out:json][timeout:180];
         way["landuse"="orchard"](${south},${west},${north},${east});
         out geom;
         relation["landuse"="orchard"](${south},${west},${north},${east});
@@ -337,11 +337,11 @@ class TreeWardenMap {
     }
     
     async fetchTreesFromOverpass(query) {
-        const overpassUrl = 'https://overpass-api.de/api/interpreter';
+        const overpassUrl = 'http://overpass-api.de/api/interpreter';
         const controller = new AbortController();
         const timeoutId = setTimeout(() => {
             controller.abort();
-        }, 10000);
+        }, 180000);
         
         try {
             const response = await fetch(overpassUrl, {
@@ -390,12 +390,12 @@ class TreeWardenMap {
     }
     
     async fetchOrchardsFromOverpass(query) {
-        const overpassUrl = 'https://overpass-api.de/api/interpreter';
+        const overpassUrl = 'http://overpass-api.de/api/interpreter';
         
         const controller = new AbortController();
         const timeoutId = setTimeout(() => {
             controller.abort();
-        }, 15000);
+        }, 180000);
         
         try {
             const response = await fetch(overpassUrl, {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Overpass API URL to HTTP and set all related timeouts to 180 seconds.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change aligns the Overpass API access with the user's specific requirements for using the HTTP protocol and a consistent 180-second timeout across API queries and JavaScript fetch operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f36a213-c741-4099-8a55-ea543c6f0e53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f36a213-c741-4099-8a55-ea543c6f0e53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>