### PR TITLE
Correct botanical name capitalization

### DIFF
--- a/app.js.legacy
+++ b/app.js.legacy
@@ -1126,7 +1126,7 @@ class TreeWardenMap {
     getGenusMapping() {
         return {
             'Malus': {
-                'species': 'Malus Domestica',
+                'species': 'Malus domestica',
                 'species:wikidata': 'Q18674606'
             },
             'Sorbus': {
@@ -1135,7 +1135,7 @@ class TreeWardenMap {
                 'species:wikipedia': 'de:Speierling'
             },
             'Pyrus': {
-                'species': 'Pyrus Communis',
+                'species': 'Pyrus communis',
                 'species:wikidata': 'Q146281'
             },
             'Prunus': {
@@ -1160,9 +1160,9 @@ class TreeWardenMap {
     getSpeciesWikidataMapping() {
         return {
             // Only keeping the most certain entries from original code
-            'Malus Domestica': 'Q158657', // DE: Kulturapfel, EN: domestic apple
+            'Malus domestica': 'Q158657', // DE: Kulturapfel, EN: domestic apple
             'Sorbus Domestica': 'Q159558', // DE: Speierling, EN: service tree  
-            'Pyrus Communis': 'Q146281', // DE: Kultur-Birne, EN: European pear
+            'Pyrus communis': 'Q146281', // DE: Kultur-Birne, EN: European pear
             'Prunus Avium': 'Q165137', // DE: Süßkirsche, EN: sweet cherry
             'Cydonia Oblonga': 'Q43300', // DE: Quitte, EN: quince
             'Juglans Regia': 'Q46871', // DE: Echte Walnuss, EN: English walnut

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -91,7 +91,7 @@ interface ITreeIssue {
 
 // Reference data for validation
 const SPECIES_REFERENCE_DATA: Record<string, Record<string, string>> = {
-  'Malus Domestica': { // DE: Kulturapfel, EN: domestic apple
+      'Malus domestica': { // DE: Kulturapfel, EN: domestic apple
     'species:wikidata': 'Q18674606',
     'genus': 'Malus'
   },
@@ -100,7 +100,7 @@ const SPECIES_REFERENCE_DATA: Record<string, Record<string, string>> = {
     'species:wikipedia': 'de:Speierling',
     'genus': 'Sorbus'
   },
-  'Pyrus Communis': {  // DE: Kultur-Birne, EN: European pear
+      'Pyrus communis': {  // DE: Kultur-Birne, EN: European pear
     'species:wikidata': 'Q146281',
     'genus': 'Pyrus'
   },
@@ -454,20 +454,20 @@ export const getTreeIssues = (tree: Tree): { errors: ITreeIssue[], warnings: ITr
     })
   } if (tree.properties.genus == 'Malus' && !tree.properties.species) {
     errors.push({
-      message: 'Der Baum hat keine Spezies. Vielleicht "Malus Domestica"?',
+      message: 'Der Baum hat keine Spezies. Vielleicht "Malus domestica"?',
       patch: [{
         key: 'species',
-        value: 'Malus Domestica'
+        value: 'Malus domestica'
       }],
       severity: 'error'
     })
   }
   if (tree.properties.genus == 'Pyrus' && !tree.properties.species) {
     errors.push({
-      message: 'Der Baum hat keine Spezies. Vielleicht "Pyrus Communis"?',
+      message: 'Der Baum hat keine Spezies. Vielleicht "Pyrus communis"?',
       patch: [{
         key: 'species',
-        value: 'Pyrus Communis'
+        value: 'Pyrus communis'
       }],
       severity: 'error'
     })


### PR DESCRIPTION
Standardize species names to 'Malus domestica' and 'Pyrus communis' to follow scientific naming conventions.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bfac124-9223-41a2-b625-b0f8a38f7654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bfac124-9223-41a2-b625-b0f8a38f7654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

