### PR TITLE
Add species:cultivar tag button

### DIFF
--- a/src/components/TreeInfo.tsx
+++ b/src/components/TreeInfo.tsx
@@ -129,6 +129,20 @@ const TreeInfo: React.FC<TreeInfoProps> = ({ tree }) => {
     }
   };
 
+  const hasSpeciesCultivarTag = () => {
+    return 'species:cultivar' in patchedTree.properties || 
+           (patch && patch.changes && 'species:cultivar' in patch.changes);
+  };
+
+  const handleAddSpeciesCultivar = () => {
+    const patchData: Record<string, string> = {};
+    patchData['species:cultivar'] = '';
+    addPatch(tree.id, tree.version || 1, patchData);
+    // Start editing the new tag immediately
+    setEditingTag('species:cultivar');
+    setEditValue('');
+  };
+
   const renderTagValue = (tagKey: string, tagValue: string) => {
     // If this tag is being edited, show input field
     if (editingTag === tagKey) {
@@ -321,6 +335,19 @@ const TreeInfo: React.FC<TreeInfoProps> = ({ tree }) => {
             }
           </div>
         </div>
+
+        {/* Add Species Cultivar Button */}
+        {!hasSpeciesCultivarTag() && (
+          <div className={styles['add-tag-button-container']}>
+            <button 
+              className={styles['add-tag-button']}
+              onClick={handleAddSpeciesCultivar}
+              title="Species:cultivar hinzufügen"
+            >
+              ➕ Species:cultivar
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/styles/tree-popup.module.css
+++ b/src/styles/tree-popup.module.css
@@ -413,4 +413,36 @@
   .tree-info-modal-content {
     padding: 15px;
   }
+}
+
+/* Add Tag Button */
+.add-tag-button-container {
+  margin-top: 10px;
+  padding: 8px 0;
+  border-top: 1px solid #e0e0e0;
+}
+
+.add-tag-button {
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+}
+
+.add-tag-button:hover {
+  background-color: #f8f9fa;
+  border-color: #ccc;
+  color: #333;
+}
+
+.add-tag-button:active {
+  background-color: #e9ecef;
+  transform: translateY(1px);
 } 

--- a/src/test/TreeInfo.test.tsx
+++ b/src/test/TreeInfo.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import TreeInfo from '../components/TreeInfo';
+import { Tree } from '../types';
+
+// Mock the patch store
+vi.mock('../store/patchStore', () => ({
+  addPatch: vi.fn(),
+  getPatchedTree: (tree: Tree) => tree
+}));
+
+// Mock the usePatchStore hook
+vi.mock('../store/usePatchStore', () => ({
+  usePatchByOsmId: () => ({ patch: null })
+}));
+
+describe('TreeInfo Component', () => {
+  it('should show add species:cultivar button when tag does not exist', () => {
+    const treeWithoutSpeciesCultivar: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        species: 'Quercus robur',
+        genus: 'Quercus'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutSpeciesCultivar} />);
+    
+    expect(screen.getByText('➕ Species:cultivar')).toBeInTheDocument();
+  });
+
+  it('should not show add species:cultivar button when tag already exists', () => {
+    const treeWithSpeciesCultivar: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        species: 'Quercus robur',
+        genus: 'Quercus',
+        'species:cultivar': 'Fastigiata'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithSpeciesCultivar} />);
+    
+    expect(screen.queryByText('➕ Species:cultivar')).not.toBeInTheDocument();
+  });
+
+  it('should call addPatch when add species:cultivar button is clicked', async () => {
+    const { addPatch } = await import('../store/patchStore');
+    const treeWithoutSpeciesCultivar: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        species: 'Quercus robur',
+        genus: 'Quercus'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutSpeciesCultivar} />);
+    
+    const addButton = screen.getByText('➕ Species:cultivar');
+    fireEvent.click(addButton);
+    
+    expect(addPatch).toHaveBeenCalledWith(1, 1, { 'species:cultivar': '' });
+  });
+});


### PR DESCRIPTION
Add an unobtrusive button to the TreeInfo panel to allow users to add a `species:cultivar` tag when one is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-185fcaf2-dc41-4b32-a868-f47bff0ebfc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-185fcaf2-dc41-4b32-a868-f47bff0ebfc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

