### PR TITLE
Adjust orchard fetching for getTreeIssues

### DIFF
--- a/src/components/TreeInfo.tsx
+++ b/src/components/TreeInfo.tsx
@@ -3,6 +3,7 @@ import { Tree } from '../types';
 import { getTreeDisplayName, getTreeIssues } from '../utils/treeUtils';
 import { addPatch, getPatchedTree } from '../store/patchStore';
 import { usePatchByOsmId } from '../store/usePatchStore';
+import { useOrchards } from '../store/useOrchardStore';
 import styles from '../styles/tree-popup.module.css';
 
 interface TreeInfoProps {
@@ -11,7 +12,8 @@ interface TreeInfoProps {
 
 const TreeInfo: React.FC<TreeInfoProps> = ({ tree }) => {
   const patchedTree = getPatchedTree(tree);
-  const { errors, warnings } = getTreeIssues(patchedTree);
+  const orchards = useOrchards();
+  const { errors, warnings } = getTreeIssues(patchedTree, orchards);
   
   // Subscribe to patchStore changes for this specific tree
   const { patch } = usePatchByOsmId(tree.id);

--- a/src/components/TreeList.tsx
+++ b/src/components/TreeList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTreeStore } from '../store/useTreeStore'
 import { usePatchStore } from '../store/usePatchStore'
+import { useOrchards } from '../store/useOrchardStore'
 import { getTreeDisplayName, getTreeIssues } from '../utils/treeUtils'
 import { Tree } from '../types'
 import styles from '../styles/tree-list.module.css'
@@ -14,6 +15,7 @@ interface TreeListProps {
 const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId }) => {
   const { trees, isLoading, error } = useTreeStore()
   const { hasPatchForOsmId } = usePatchStore()
+  const orchards = useOrchards()
 
   const handleTreeClick = (tree: Tree) => {
     onTreeSelect(tree)
@@ -64,7 +66,7 @@ const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId }) => 
           <ul className={styles['tree-items']}>
             {sortedTrees.map((tree) => {
               const patchedTree = getPatchedTree(tree)
-              const { errors, warnings } = getTreeIssues(patchedTree)
+              const { errors, warnings } = getTreeIssues(patchedTree, orchards)
               const hasErrors = errors.length > 0
               const hasWarnings = warnings.length > 0
               const isSelected = tree.id === selectedTreeId

--- a/src/store/orchardStore.ts
+++ b/src/store/orchardStore.ts
@@ -1,0 +1,124 @@
+import { atom, computed } from 'nanostores';
+import { OverpassService } from '../services/overpass';
+import { Orchard, MapBounds } from '../types';
+
+// Store state
+export const orchards = atom<Orchard[]>([]);
+export const orchardLoading = atom<boolean>(false);
+export const orchardError = atom<string | null>(null);
+export const orchardBounds = atom<MapBounds | null>(null);
+export const orchardLastUpdated = atom<Date | null>(null);
+
+// Computed values
+export const orchardCount = computed(orchards, (orchardsState) => orchardsState.length);
+export const hasOrchards = computed(orchards, (orchardsState) => orchardsState.length > 0);
+export const isOrchardLoading = computed(orchardLoading, (loading) => loading);
+export const hasOrchardError = computed(orchardError, (error) => error !== null);
+
+// Utility function to check if bounds change is significant enough to reload orchards
+function hasSignificantOrchardBoundsChange(newBounds: MapBounds, currentBounds: MapBounds | null): boolean {
+  if (!currentBounds) return true;
+
+  // For orchards, use a larger threshold since they cover bigger areas
+  const latThreshold = 0.02; // ~2.2km
+  const lngThreshold = 0.02; // ~2.2km (varies by latitude)
+  const zoomThreshold = 1.5; // More tolerant zoom changes
+
+  const latDiff = Math.abs(newBounds.north - currentBounds.north) + Math.abs(newBounds.south - currentBounds.south);
+  const lngDiff = Math.abs(newBounds.east - currentBounds.east) + Math.abs(newBounds.west - currentBounds.west);
+
+  const hasSignificantPan = latDiff > latThreshold || lngDiff > lngThreshold;
+
+  // Calculate zoom level difference (approximation based on bounds size)
+  const currentSize = (currentBounds.north - currentBounds.south) * (currentBounds.east - currentBounds.west);
+  const newSize = (newBounds.north - newBounds.south) * (newBounds.east - newBounds.west);
+  const sizeDiff = Math.abs(Math.log(newSize / currentSize));
+  const hasSignificantZoom = sizeDiff > zoomThreshold;
+
+  return hasSignificantPan || hasSignificantZoom;
+}
+
+// Calculate expanded bounds for orchard fetching (larger area than trees)
+function calculateOrchardBounds(treeBounds: MapBounds): MapBounds {
+  const latDiff = treeBounds.north - treeBounds.south;
+  const lngDiff = treeBounds.east - treeBounds.west;
+  
+  // Use larger expansion for orchards (4.5x as in legacy code)
+  const latExpansion = latDiff * 4.5;
+  const lngExpansion = lngDiff * 4.5;
+  
+  return {
+    south: treeBounds.south - latExpansion,
+    west: treeBounds.west - lngExpansion,
+    north: treeBounds.north + latExpansion,
+    east: treeBounds.east + lngExpansion
+  };
+}
+
+// Actions
+export async function loadOrchardsForBounds(treeBounds: MapBounds, forceReload: boolean = false): Promise<void> {
+  const expandedBounds = calculateOrchardBounds(treeBounds);
+  const currentBounds = orchardBounds.get();
+  
+  // Check if we need to reload based on significant changes
+  if (!forceReload && !hasSignificantOrchardBoundsChange(expandedBounds, currentBounds)) {
+    console.log('🍎 Orchard bounds change not significant enough, skipping orchard reload');
+    console.log('Current orchard bounds:', currentBounds);
+    console.log('New orchard bounds:', expandedBounds);
+    return;
+  }
+
+  try {
+    orchardLoading.set(true);
+    orchardError.set(null);
+    
+    // Add a small delay to ensure this runs with lower priority than trees
+    await new Promise(resolve => setTimeout(resolve, 100));
+    
+    console.log('🍎 Starting orchard fetch with low priority...');
+    const fetchedOrchards = await OverpassService.fetchOrchards(expandedBounds);
+    
+    orchards.set(fetchedOrchards);
+    orchardBounds.set(expandedBounds);
+    orchardLastUpdated.set(new Date());
+    
+    console.log(`🍎 Loaded ${fetchedOrchards.length} orchards for expanded bounds:`, expandedBounds);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred while loading orchards';
+    orchardError.set(errorMessage);
+    orchards.set([]);
+    console.error('Error loading orchards:', err);
+  } finally {
+    orchardLoading.set(false);
+  }
+}
+
+export function clearOrchards(): void {
+  orchards.set([]);
+  orchardBounds.set(null);
+  orchardLastUpdated.set(null);
+  orchardError.set(null);
+}
+
+export function clearOrchardError(): void {
+  orchardError.set(null);
+}
+
+export function setOrchardError(errorMessage: string): void {
+  orchardError.set(errorMessage);
+}
+
+// Utility functions
+export function getOrchardsInBounds(bounds: MapBounds): Orchard[] {
+  return orchards.get().filter(orchard => {
+    // Check if any coordinate of the orchard is within bounds
+    return orchard.coordinates.some(([lat, lon]) => 
+      lat >= bounds.south && lat <= bounds.north &&
+      lon >= bounds.west && lon <= bounds.east
+    );
+  });
+}
+
+export function getOrchardById(id: number): Orchard | undefined {
+  return orchards.get().find(orchard => orchard.id === id);
+}

--- a/src/store/treeStore.ts
+++ b/src/store/treeStore.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores';
 import { OverpassService } from '../services/overpass';
 import { Tree, MapBounds } from '../types';
+import { loadOrchardsForBounds } from './orchardStore';
 
 // Store state
 export const trees = atom<Tree[]>([]);
@@ -81,6 +82,11 @@ export async function loadTreesForBounds(newBounds: MapBounds, forceReload: bool
     lastUpdated.set(new Date());
     
     console.log(`Loaded ${fetchedTrees.length} trees for bounds:`, newBounds);
+    
+    // After trees are loaded successfully, start low-priority orchard loading
+    loadOrchardsForBounds(newBounds, forceReload).catch(err => {
+      console.warn('Failed to load orchards after tree loading:', err);
+    });
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
     error.set(errorMessage);

--- a/src/store/useOrchardStore.ts
+++ b/src/store/useOrchardStore.ts
@@ -1,0 +1,58 @@
+import { useStore } from '@nanostores/react';
+import { 
+  orchards, 
+  orchardLoading, 
+  orchardError, 
+  orchardBounds, 
+  orchardLastUpdated,
+  orchardCount,
+  hasOrchards,
+  isOrchardLoading,
+  hasOrchardError,
+  loadOrchardsForBounds,
+  clearOrchards,
+  setOrchardError,
+  clearOrchardError,
+  getOrchardsInBounds,
+  getOrchardById
+} from './orchardStore';
+
+export function useOrchardStore() {
+  return {
+    // State
+    orchards: useStore(orchards),
+    loading: useStore(orchardLoading),
+    error: useStore(orchardError),
+    bounds: useStore(orchardBounds),
+    lastUpdated: useStore(orchardLastUpdated),
+    
+    // Computed
+    orchardCount: useStore(orchardCount),
+    hasOrchards: useStore(hasOrchards),
+    isLoading: useStore(isOrchardLoading),
+    hasError: useStore(hasOrchardError),
+    
+    // Actions
+    loadOrchardsForBounds,
+    clearOrchards,
+    setOrchardError,
+    clearOrchardError,
+    
+    // Utilities
+    getOrchardsInBounds,
+    getOrchardById
+  };
+}
+
+// Specific hooks for individual stores
+export function useOrchards() {
+  return useStore(orchards);
+}
+
+export function useOrchardLoading() {
+  return useStore(orchardLoading);
+}
+
+export function useOrchardError() {
+  return useStore(orchardError);
+}


### PR DESCRIPTION
Refactor orchard fetching to be sequential and low-priority, loading only after trees are fetched, to improve initial load performance and reduce Overpass API load.

This change addresses concerns about parallel fetching, ensuring that core tree data loads quickly. Orchard-related suggestions, such as `denotation: agricultural`, are now applied as an enhancement once the orchard data is available, with `getTreeIssues()` gracefully handling the initial absence of orchard data.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce58d564-5e3b-489b-8140-8687716b0946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce58d564-5e3b-489b-8140-8687716b0946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

