### PR TITLE
Implement closing tree-info panel

### DIFF
--- a/src/components/TreeInfo.tsx
+++ b/src/components/TreeInfo.tsx
@@ -8,9 +8,10 @@ import styles from '../styles/tree-popup.module.css';
 
 interface TreeInfoProps {
   tree: Tree;
+  onClose?: () => void;
 }
 
-const TreeInfo: React.FC<TreeInfoProps> = ({ tree }) => {
+const TreeInfo: React.FC<TreeInfoProps> = ({ tree, onClose }) => {
   const patchedTree = getPatchedTree(tree);
   const orchards = useOrchards();
   const { errors, warnings } = getTreeIssues(patchedTree, orchards);
@@ -218,19 +219,30 @@ const TreeInfo: React.FC<TreeInfoProps> = ({ tree }) => {
   return (
     <div className={styles['tree-info']}>
       <div className={styles['tree-info-header']}>
-        <h3 className={styles['tree-name']}>{getTreeDisplayName(tree)}</h3>
-        <div className={styles['tree-osm-details']}>
-        OSM ID: {' '} <a 
-            href={createOsmLink(tree.id)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles['tree-osm-id']}
-          >{tree.id}
-          </a>
-          {tree.version && (
-            <span className={styles['tree-osm-version']}>Version: {tree.version}</span>
-          )}
+        <div className={styles['tree-info-header-content']}>
+          <h3 className={styles['tree-name']}>{getTreeDisplayName(tree)}</h3>
+          <div className={styles['tree-osm-details']}>
+          OSM ID: {' '} <a 
+              href={createOsmLink(tree.id)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles['tree-osm-id']}
+            >{tree.id}
+            </a>
+            {tree.version && (
+              <span className={styles['tree-osm-version']}>Version: {tree.version}</span>
+            )}
+          </div>
         </div>
+        {onClose && (
+          <button 
+            className={styles['close-button']} 
+            onClick={onClose}
+            title="Tree-Info Panel schließen"
+          >
+            ×
+          </button>
+        )}
       </div>
       
       <div className={styles['tree-info-content']}>

--- a/src/components/TreeInfoSlidein.tsx
+++ b/src/components/TreeInfoSlidein.tsx
@@ -20,7 +20,7 @@ const TreeInfoSlidein: React.FC<TreeInfoSlideinProps> = ({ tree, isOpen, onClose
           className={styles['tree-info-sidebar']}
           onClick={(e) => e.stopPropagation()}
         >
-          <TreeInfo tree={tree} />
+          <TreeInfo tree={tree} onClose={onClose} />
         </div>
       )}
     </div>

--- a/src/styles/tree-popup.module.css
+++ b/src/styles/tree-popup.module.css
@@ -9,6 +9,13 @@
   margin-bottom: 15px;
   padding-bottom: 10px;
   border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.tree-info-header-content {
+  flex: 1;
 }
 
 .tree-name {
@@ -445,4 +452,27 @@
 .add-tag-button:active {
   background-color: #e9ecef;
   transform: translateY(1px);
+}
+
+/* Close Button */
+.close-button {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #666;
+  cursor: pointer;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.close-button:hover {
+  background: #e0e0e0;
+  color: #333;
 } 


### PR DESCRIPTION
Add a close button to the Tree-Info Panel for an explicit closing mechanism, consistent with other slide-in components.

---
<a href="https://cursor.com/background-agent?bcId=bc-278a51cc-55b6-4b3a-bc66-899d85a47cfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-278a51cc-55b6-4b3a-bc66-899d85a47cfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>