### PR TITLE
fix OSM upload error

### DIFF
--- a/src/utils/__tests__/osmXmlUtils.test.ts
+++ b/src/utils/__tests__/osmXmlUtils.test.ts
@@ -243,10 +243,9 @@ describe('osmXmlUtils', () => {
       expect(result).toContain('<tag k="created_by" v="TreeWarden"/>');
       expect(result).toContain('<tag k="comment" v="Test changes"/>');
       expect(result).toContain('</changeset>');
-      expect(result).toContain('<node id="12345" lat="50.123" lon="7.456" version="2">');
-      expect(result).toContain('<tag k="genus" v="Quercus"/>');
-      expect(result).toContain('<tag k="species" v="Quercus robur"/>');
       expect(result).toContain('</osm>');
+      // Changeset creation XML should NOT contain node elements
+      expect(result).not.toContain('<node');
     });
 
     it('should generate changes XML when changesetId is provided', () => {
@@ -320,10 +319,14 @@ describe('osmXmlUtils', () => {
         ]
       };
 
-      const result = generateOSMXML(changesetData, null);
+      // Test changeset creation XML (should only escape changeset tags)
+      const changesetResult = generateOSMXML(changesetData, null);
+      expect(changesetResult).toContain('<tag k="comment" v="Test with &amp; &lt; &gt; &quot; &#39; characters"/>');
+      expect(changesetResult).not.toContain('<node'); // No nodes in changeset creation
 
-      expect(result).toContain('<tag k="comment" v="Test with &amp; &lt; &gt; &quot; &#39; characters"/>');
-      expect(result).toContain('<tag k="note" v="Tree with &amp; special &lt;characters&gt; and &quot;quotes&quot;"/>');
+      // Test changes XML (should escape node tags)
+      const changesResult = generateOSMXML(changesetData, '999');
+      expect(changesResult).toContain('<tag k="note" v="Tree with &amp; special &lt;characters&gt; and &quot;quotes&quot;"/>');
     });
   });
 

--- a/src/utils/osmUploadUtils.ts
+++ b/src/utils/osmUploadUtils.ts
@@ -55,7 +55,7 @@ export async function uploadToOSM(
     });
 
     // Step 3: Upload changes
-    const changesXml = generateOSMXML(uploadData);
+    const changesXml = generateOSMXML(uploadData, changesetId);
     console.log('📤 Uploading changes to changeset', changesetId);
     
     const uploadResponse = await osmAuthInstance.fetch(`https://api.openstreetmap.org/api/0.6/changeset/${changesetId}/upload`, {

--- a/src/utils/osmXmlUtils.ts
+++ b/src/utils/osmXmlUtils.ts
@@ -37,7 +37,7 @@ export function generateOSMXML(changesetData: ChangesetData, changesetId: string
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
   
   if (changesetId) {
-    // Generate changes XML
+    // Generate changes XML for uploading to an existing changeset
     xml += '<osmChange version="0.6" generator="TreeWarden">\n';
     
     if (changesetData.modify.length > 0) {
@@ -54,29 +54,16 @@ export function generateOSMXML(changesetData: ChangesetData, changesetId: string
     
     xml += '</osmChange>';
   } else {
-    // Generate changeset XML with modify nodes
+    // Generate changeset creation XML (should only contain changeset metadata, no nodes)
     xml += '<osm version="0.6" generator="TreeWarden">\n';
     xml += '  <changeset>\n';
     changesetData.changeset?.tag.forEach((tag: { k: string; v: string }) => {
       xml += `    <tag k="${escapeXml(tag.k)}" v="${escapeXml(tag.v)}"/>\n`;
     });
     xml += '  </changeset>\n';
-    
-    // Include modify nodes in the changeset XML
-    if (changesetData.modify && changesetData.modify.length > 0) {
-      changesetData.modify.forEach((node: OSMNode) => {
-        xml += `  <node id="${node.id}" lat="${node.lat}" lon="${node.lon}" version="${node.version}">\n`;
-        node.tag.forEach((tag: OSMTag) => {
-          xml += `    <tag k="${escapeXml(tag.k)}" v="${escapeXml(tag.v)}"/>\n`;
-        });
-        xml += '  </node>\n';
-      });
-    }
-    
     xml += '</osm>';
   }
   
-  xml += '</osm>';
   console.log('🔍 Generated XML length:', xml.length);
   console.log('🔍 Generated XML preview:', xml.substring(0, 500) + '...');
   


### PR DESCRIPTION
Fixes OSM upload error by correcting XML generation for changeset creation and ensuring proper changes upload.

The previous implementation generated malformed XML for changeset creation (including node data and a duplicate `</osm>` tag) and the subsequent changes upload call incorrectly generated changeset creation XML due to a missing `changesetId`. This led to a `HTTP 400 : Cannot parse valid changeset from xml string` error from the OSM API.

---
<a href="https://cursor.com/background-agent?bcId=bc-d532f955-eada-42da-b2ed-298520f168bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d532f955-eada-42da-b2ed-298520f168bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>