### PR TITLE
Add genus and species tags

### DIFF
--- a/src/components/TreeInfo.tsx
+++ b/src/components/TreeInfo.tsx
@@ -137,12 +137,40 @@ const TreeInfo: React.FC<TreeInfoProps> = ({ tree, onClose }) => {
            (patch && patch.changes && 'species:cultivar' in patch.changes);
   };
 
+  const hasGenusTag = () => {
+    return 'genus' in patchedTree.properties || 
+           (patch && patch.changes && 'genus' in patch.changes);
+  };
+
+  const hasSpeciesTag = () => {
+    return 'species' in patchedTree.properties || 
+           (patch && patch.changes && 'species' in patch.changes);
+  };
+
   const handleAddSpeciesCultivar = () => {
     const patchData: Record<string, string> = {};
     patchData['species:cultivar'] = '';
     addPatch(tree.id, tree.version || 1, patchData);
     // Start editing the new tag immediately
     setEditingTag('species:cultivar');
+    setEditValue('');
+  };
+
+  const handleAddGenus = () => {
+    const patchData: Record<string, string> = {};
+    patchData['genus'] = '';
+    addPatch(tree.id, tree.version || 1, patchData);
+    // Start editing the new tag immediately
+    setEditingTag('genus');
+    setEditValue('');
+  };
+
+  const handleAddSpecies = () => {
+    const patchData: Record<string, string> = {};
+    patchData['species'] = '';
+    addPatch(tree.id, tree.version || 1, patchData);
+    // Start editing the new tag immediately
+    setEditingTag('species');
     setEditValue('');
   };
 
@@ -350,18 +378,44 @@ const TreeInfo: React.FC<TreeInfoProps> = ({ tree, onClose }) => {
           </div>
         </div>
 
-        {/* Add Species Cultivar Button */}
-        {!hasSpeciesCultivarTag() && (
-          <div className={styles['add-tag-button-container']}>
-            <button 
-              className={styles['add-tag-button']}
-              onClick={handleAddSpeciesCultivar}
-              title="Species:cultivar hinzufügen"
-            >
-              ➕ Species:cultivar
-            </button>
-          </div>
-        )}
+        {/* Add Tag Buttons */}
+        <div className={styles['add-tag-buttons']}>
+          {!hasGenusTag() && (
+            <div className={styles['add-tag-button-container']}>
+              <button 
+                className={styles['add-tag-button']}
+                onClick={handleAddGenus}
+                title="Genus hinzufügen"
+              >
+                ➕ Genus
+              </button>
+            </div>
+          )}
+          
+          {!hasSpeciesTag() && (
+            <div className={styles['add-tag-button-container']}>
+              <button 
+                className={styles['add-tag-button']}
+                onClick={handleAddSpecies}
+                title="Species hinzufügen"
+              >
+                ➕ Species
+              </button>
+            </div>
+          )}
+
+          {!hasSpeciesCultivarTag() && (
+            <div className={styles['add-tag-button-container']}>
+              <button 
+                className={styles['add-tag-button']}
+                onClick={handleAddSpeciesCultivar}
+                title="Species:cultivar hinzufügen"
+              >
+                ➕ Species:cultivar
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/test/TreeInfo.test.tsx
+++ b/src/test/TreeInfo.test.tsx
@@ -16,6 +16,109 @@ vi.mock('../store/usePatchStore', () => ({
 }));
 
 describe('TreeInfo Component', () => {
+  // Genus tag tests
+  it('should show add genus button when genus tag does not exist', () => {
+    const treeWithoutGenus: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        species: 'Quercus robur'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutGenus} />);
+    
+    expect(screen.getByText('➕ Genus')).toBeInTheDocument();
+  });
+
+  it('should not show add genus button when genus tag already exists', () => {
+    const treeWithGenus: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        genus: 'Quercus',
+        species: 'Quercus robur'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithGenus} />);
+    
+    expect(screen.queryByText('➕ Genus')).not.toBeInTheDocument();
+  });
+
+  it('should call addPatch when add genus button is clicked', async () => {
+    const { addPatch } = await import('../store/patchStore');
+    const treeWithoutGenus: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        species: 'Quercus robur'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutGenus} />);
+    
+    const addButton = screen.getByText('➕ Genus');
+    fireEvent.click(addButton);
+    
+    expect(addPatch).toHaveBeenCalledWith(1, 1, { 'genus': '' });
+  });
+
+  // Species tag tests
+  it('should show add species button when species tag does not exist', () => {
+    const treeWithoutSpecies: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        genus: 'Quercus'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutSpecies} />);
+    
+    expect(screen.getByText('➕ Species')).toBeInTheDocument();
+  });
+
+  it('should not show add species button when species tag already exists', () => {
+    const treeWithSpecies: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        genus: 'Quercus',
+        species: 'Quercus robur'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithSpecies} />);
+    
+    expect(screen.queryByText('➕ Species')).not.toBeInTheDocument();
+  });
+
+  it('should call addPatch when add species button is clicked', async () => {
+    const { addPatch } = await import('../store/patchStore');
+    const treeWithoutSpecies: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {
+        genus: 'Quercus'
+      }
+    };
+
+    render(<TreeInfo tree={treeWithoutSpecies} />);
+    
+    const addButton = screen.getByText('➕ Species');
+    fireEvent.click(addButton);
+    
+    expect(addPatch).toHaveBeenCalledWith(1, 1, { 'species': '' });
+  });
+
+  // Species:cultivar tag tests (existing functionality)
   it('should show add species:cultivar button when tag does not exist', () => {
     const treeWithoutSpeciesCultivar: Tree = {
       id: 1,
@@ -67,5 +170,21 @@ describe('TreeInfo Component', () => {
     fireEvent.click(addButton);
     
     expect(addPatch).toHaveBeenCalledWith(1, 1, { 'species:cultivar': '' });
+  });
+
+  // Test showing multiple buttons when multiple tags are missing
+  it('should show multiple add buttons when multiple tags are missing', () => {
+    const treeWithMinimalTags: Tree = {
+      id: 1,
+      lat: 50.897146,
+      lon: 7.098337,
+      properties: {}
+    };
+
+    render(<TreeInfo tree={treeWithMinimalTags} />);
+    
+    expect(screen.getByText('➕ Genus')).toBeInTheDocument();
+    expect(screen.getByText('➕ Species')).toBeInTheDocument();
+    expect(screen.getByText('➕ Species:cultivar')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Add functionality to add `genus` and `species` tags to existing trees when missing, mirroring the existing `species:cultivar` feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac19f5f2-fd10-4bd8-b6bb-cfd2f14c0be3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac19f5f2-fd10-4bd8-b6bb-cfd2f14c0be3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>