### PR TITLE
Investigate empty osm changeset upload

### DIFF
--- a/src/utils/__tests__/osmXmlUtils.test.ts
+++ b/src/utils/__tests__/osmXmlUtils.test.ts
@@ -113,7 +113,7 @@ describe('osmXmlUtils', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle patches with missing tree versions', () => {
+    it('should handle patches with missing tree versions by using patch version', () => {
       const patches: Record<number, TreePatch> = {
         12345: {
           osmId: 12345,
@@ -129,11 +129,44 @@ describe('osmXmlUtils', () => {
           id: 12345,
           lat: 50.123,
           lon: 7.456,
-          // Missing version
+          // Missing version - should use patch.version instead
           type: 'node',
           properties: {}
         }
       ];
+
+      const result = generateOSMUploadData(patches, trees);
+
+      expect(result).not.toBeNull();
+      expect(result?.modify).toHaveLength(1);
+      expect(result?.modify[0].version).toBe(2); // Should use patch.version
+      expect(result?.modify[0].id).toBe(12345);
+    });
+
+    it('should return null when patch version is missing for existing trees', () => {
+      const patches: Record<number, TreePatch> = {
+        12345: {
+          osmId: 12345,
+          version: 0, // Invalid version for existing tree
+          changes: {
+            genus: 'Quercus'
+          }
+        }
+      };
+
+      const trees: Tree[] = [
+        {
+          id: 12345,
+          lat: 50.123,
+          lon: 7.456,
+          version: 2,
+          type: 'node',
+          properties: {}
+        }
+      ];
+
+      // Simulate missing patch version by setting it to undefined
+      patches[12345].version = undefined as any;
 
       const result = generateOSMUploadData(patches, trees);
 

--- a/src/utils/osmXmlUtils.ts
+++ b/src/utils/osmXmlUtils.ts
@@ -182,11 +182,11 @@ export function generateOSMUploadData(patches: Record<number, TreePatch>, trees:
         // Handle existing tree modification
         console.log('🔍 Modifying existing tree node...');
         console.log('🔍 Tree coordinates:', { lat: tree.lat, lon: tree.lon });
-        console.log('🔍 Tree version:', tree.version);
+        console.log('🔍 Patch version:', patch.version);
         console.log('🔍 Patch changes:', patch.changes);
         
-        // For modified nodes, we must have the version from the server
-        if (!tree.version) {
+        // For modified nodes, we must have the version from the patch
+        if (!patch.version) {
           console.error(`❌ Missing version for node ${patch.osmId}. Cannot upload modifications without version.`);
           hasMissingVersions = true;
           return;
@@ -219,7 +219,7 @@ export function generateOSMUploadData(patches: Record<number, TreePatch>, trees:
           id: patch.osmId,
           lat: tree.lat,
           lon: tree.lon,
-          version: tree.version!, // We validated this exists above
+          version: patch.version!, // We validated this exists above
           tag: Array.from(tagMap.entries()).map(([k, v]) => ({ k, v }))
         };
 


### PR DESCRIPTION
Fix OSM upload by using `patch.version` for existing tree modifications instead of `tree.version` to ensure changes are uploaded.

The `generateOSMUploadData` function was returning `null` for existing tree modifications because it incorrectly expected `tree.version` to be present. `tree.version` can be undefined, leading to empty changesets. The `patch.version` is the correct and always-present source of version information for changes, aligning the upload logic with the `convertPatchesToOsmChange` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3ee8b65-ff23-42b4-856a-0a20f60b0d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3ee8b65-ff23-42b4-856a-0a20f60b0d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>