### PR TITLE
Investigate osm change file read failure

### DIFF
--- a/src/components/UploadManager.tsx
+++ b/src/components/UploadManager.tsx
@@ -104,9 +104,10 @@ const UploadManager: React.FC<UploadManagerProps> = ({ onClose }) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
-    // Check file extension
-    if (!file.name.toLowerCase().endsWith('.osc')) {
-      setFileUploadMessage('❌ Please select a .osc file (OsmChange format)');
+    // Check file extension - accept both .osc and .osc.xml extensions
+    const fileName = file.name.toLowerCase();
+    if (!fileName.endsWith('.osc') && !fileName.endsWith('.osc.xml')) {
+      setFileUploadMessage('❌ Please select a .osc or .osc.xml file (OsmChange format)');
       return;
     }
 
@@ -286,7 +287,7 @@ const UploadManager: React.FC<UploadManagerProps> = ({ onClose }) => {
             <span className={styles['store-label']}>OsmChange laden:</span>
             <input
               type="file"
-              accept=".osc"
+              accept=".osc,.osc.xml"
               onChange={handleFileUpload}
               style={{ display: 'none' }}
               id="osmchange-file-input"


### PR DESCRIPTION
Update OSM Change file validation to accept both `.osc` and `.osc.xml` extensions to support valid file formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba52eaa0-3c86-4629-948f-87ab87c68df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba52eaa0-3c86-4629-948f-87ab87c68df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>