### PR TITLE
Investigate tree list scroll issue on ipad

### DIFF
--- a/src/components/TreeList.tsx
+++ b/src/components/TreeList.tsx
@@ -39,6 +39,25 @@ const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId, onClo
     }
   }
 
+  // Handle touch events for iPad scrolling
+  const handleTouchStart = (e: React.TouchEvent) => {
+    // Allow touch events to proceed for scrolling
+    // Stop propagation to prevent map interaction
+    e.stopPropagation()
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    // Allow touch move events to proceed for scrolling
+    // Stop propagation to prevent map interaction
+    e.stopPropagation()
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    // Allow touch end events to proceed
+    // Stop propagation to prevent map interaction
+    e.stopPropagation()
+  }
+
   if (isLoading) {
     return (
       <div className={styles['tree-list']}>
@@ -54,7 +73,13 @@ const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId, onClo
             </button>
           )}
         </div>
-        <div className={styles['tree-list-content']} onWheel={handleWheel}>
+        <div 
+          className={styles['tree-list-content']} 
+          onWheel={handleWheel}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
           <p>Bäume werden geladen...</p>
         </div>
       </div>
@@ -76,7 +101,13 @@ const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId, onClo
             </button>
           )}
         </div>
-        <div className={styles['tree-list-content']} onWheel={handleWheel}>
+        <div 
+          className={styles['tree-list-content']} 
+          onWheel={handleWheel}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
           <p className={styles.error}>Fehler: {error}</p>
         </div>
       </div>
@@ -98,7 +129,13 @@ const TreeList: React.FC<TreeListProps> = ({ onTreeSelect, selectedTreeId, onClo
         )}
       </div>
 
-      <div className={styles['tree-list-content']} onWheel={handleWheel}>
+      <div 
+        className={styles['tree-list-content']} 
+        onWheel={handleWheel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
         {trees.length === 0 ? (
           <p>Keine Bäume in diesem Bereich gefunden.</p>
         ) : (

--- a/src/styles/tree-list.module.css
+++ b/src/styles/tree-list.module.css
@@ -10,7 +10,7 @@
 }
 
 .tree-list-window-container.open {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .tree-list-toggle {
@@ -96,6 +96,8 @@
   flex: 1;
   overflow-y: auto;
   padding: 10px;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
 }
 
 .tree-list-content p {


### PR DESCRIPTION
Fix iPad scrolling for the Tree List by correcting CSS pointer events and adding touch event handlers.

The Tree List panel was not scrollable on iPads because `pointer-events: none` prevented touch interactions, `touch-action` was not defined, and only mouse `onWheel` events were handled. This led to taps passing through to the underlying map. This PR resolves these issues to allow proper touch-based scrolling within the panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4616658-519d-4d77-9362-2373b278e383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4616658-519d-4d77-9362-2373b278e383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>